### PR TITLE
Multi locale support

### DIFF
--- a/bin/merge_missing_translations
+++ b/bin/merge_missing_translations
@@ -19,71 +19,73 @@ def flatten_hash(hash, keys=[], result = {})
 end
 
 if File.exist?("config/missing_translations.yml")
-  master_language = YAML.load_file("config/locales/nl.yml")
+  missing_translation_hash = YAML.load_file("config/missing_translations.yml")
+  raise "Missing translations not YAML" unless missing_translation_hash.kind_of?(Hash)
 
-  if ARGV[0] and ARGV[0].strip == "--unused"
-    missing_translations = YAML.load_file("config/missing_translations.yml")
-    unused_translations = YAML.load_file("config/nl.unused.yml")
-    flat_missing_translations = flatten_hash(missing_translations)
-    flat_unused_translations = flatten_hash(unused_translations)
+  missing_translation_hash&.each do |locale, locale_translations|
+    master_language = YAML.load_file("config/locales/#{locale}.yml")
+    missing_translations = { "#{locale}": locale_translations }.deep_stringify_keys
 
-    found_translations = {}
+    if ARGV[0] and ARGV[0].strip == "--unused"
+      unused_translations = YAML.load_file("config/#{locale}.unused.yml")
+      flat_missing_translations = flatten_hash(missing_translations)
+      flat_unused_translations = flatten_hash(unused_translations)
 
-    flat_missing_translations.each do |scope, _|
-      while scope.length >= 2
-        if flat_unused_translations[scope]
-          found_translations[scope] = flat_unused_translations[scope]
-          break
-        else
-          key = scope.pop
-          scope.pop
-          scope << key
+      found_translations = {}
+
+      flat_missing_translations.each do |scope, _|
+        while scope.length >= 2
+          if flat_unused_translations[scope]
+            found_translations[scope] = flat_unused_translations[scope]
+            break
+          else
+            key = scope.pop
+            scope.pop
+            scope << key
+          end
         end
+      end
+
+      missing_translations = {}
+      found_translations.each do |key, value|
+        hash = value
+        key.reverse.each { |key| hash = { key => hash } }
+        missing_translations = missing_translations.deep_merge(hash)
       end
     end
 
-    missing_translations = {}
-    found_translations.each do |key, value|
-      hash = value
-      key.reverse.each { |key| hash = { key => hash } }
-      missing_translations = missing_translations.deep_merge(hash)
+    proc = Proc.new { |k, v|
+      if v.kind_of?(Hash)
+        v.delete_if(&proc)
+        v.empty?
+      else
+        v.nil? or (v.respond_to?(:empty?) and v.empty?)
+      end
+    }
+
+    missing_translations.delete_if(&proc)
+    missing_translations.deep_merge!(master_language)
+
+    proc = Proc.new do |v|
+      if v.kind_of?(Hash)
+        v.transform_keys(&:to_s).sort_by {|key, _| key }.to_h.transform_values(&proc)
+      else
+        v
+      end
     end
-  else
-    missing_translations = YAML.load_file("config/missing_translations.yml")
-    raise "Missing translations not YAML" unless missing_translations.kind_of?(Hash)
+
+    result_string = ""
+    missing_translations.transform_keys(&:to_s).transform_values(&proc).to_yaml(line_width: -1).each_line { |l| result_string += (l.rstrip + "\n") }
+
+    f = File.open("config/locales/#{locale}.yml", "w")
+    f.write(result_string)
+    f.close
+
+    puts "Merged missing_translations.yml into #{locale}.yml"
   end
-
-  proc = Proc.new { |k, v|
-    if v.kind_of?(Hash)
-      v.delete_if(&proc)
-      v.empty?
-    else
-      v.nil? or (v.respond_to?(:empty?) and v.empty?)
-    end
-  }
-
-  missing_translations.delete_if(&proc)
-  missing_translations.deep_merge!(master_language)
-
-  proc = Proc.new do |v|
-    if v.kind_of?(Hash)
-      v.transform_keys(&:to_s).sort_by {|key, _| key }.to_h.transform_values(&proc)
-    else
-      v
-    end
-  end
-
-  result_string = ""
-  missing_translations.transform_keys(&:to_s).transform_values(&proc).to_yaml(line_width: -1).each_line { |l| result_string += (l.rstrip + "\n") }
-
-  f = File.open("config/locales/nl.yml", "w")
-  f.write(result_string)
-  f.close
 
   f = File.open("config/missing_translations.yml", "w")
   f.close
-
-  puts "Merged missing_translations.yml into nl.yml"
 else
   puts "No missing translations"
 end

--- a/lib/i18n/workflow/exception_handler.rb
+++ b/lib/i18n/workflow/exception_handler.rb
@@ -77,7 +77,7 @@ module I18n
       # Stores the missing translations in config/missing_translations.yml and
       # clears the missing translations. If config/missing_translations.yml exists
       # and contains translations, the new missing translations are merged.
-      def store_missing_translations(locale=nil)
+      def store_missing_translations(locale=nil, duplicate_to_locales: [])
         return unless missing_translations?
         missing_translations_path = 'config/missing_translations.yml'
 
@@ -89,6 +89,7 @@ module I18n
         current_missing_translations = {} unless current_missing_translations.is_a?(Hash)
 
         proc = Proc.new do |v|
+          pp v
           if v.kind_of?(Hash)
             v.transform_keys(&:to_s).sort_by {|key, _| key.to_s }.to_h.transform_values(&proc)
           else
@@ -96,8 +97,22 @@ module I18n
           end
         end
 
+        pp "jooos"
+
+        missing_translation_hash = missing_translations_to_hash(locale)
+                                    .deep_stringify_keys
+                                    .deep_merge(current_missing_translations)
+                                    .transform_keys(&:to_s)
+                                    .transform_values(&proc)
+
+        duplicate_to_locales.each do |available_locale|
+          next if missing_translation_hash.keys.include?(available_locale)
+
+          missing_translation_hash[available_locale] = missing_translation_hash[locale.to_s]
+        end
+
         file = File.open(missing_translations_path, "w+")
-        file.write(missing_translations_to_hash(locale).deep_stringify_keys.deep_merge(current_missing_translations).transform_keys(&:to_s).transform_values(&proc).to_yaml(line_width: -1))
+        file.write(missing_translation_hash.deep_stringify_keys.to_yaml(line_width: -1))
         file.close
 
         clear_missing_translations

--- a/lib/i18n/workflow/exception_handler.rb
+++ b/lib/i18n/workflow/exception_handler.rb
@@ -89,15 +89,12 @@ module I18n
         current_missing_translations = {} unless current_missing_translations.is_a?(Hash)
 
         proc = Proc.new do |v|
-          pp v
           if v.kind_of?(Hash)
             v.transform_keys(&:to_s).sort_by {|key, _| key.to_s }.to_h.transform_values(&proc)
           else
             v
           end
         end
-
-        pp "jooos"
 
         missing_translation_hash = missing_translations_to_hash(locale)
                                     .deep_stringify_keys

--- a/spec/i18n/workflow/exception_handler_spec.rb
+++ b/spec/i18n/workflow/exception_handler_spec.rb
@@ -75,7 +75,7 @@ describe I18n::Workflow::ExceptionHandler do
       [:nl, :missing_scope, :foobar],
       [:nl, :translation]
     ])
-    expect(subject.missing_translations_to_yaml).to eq("---\nnl:\n  missing_scope:\n    foobar: \'\'\n    key_scope:\n      foobar: \'\'\n      translation: \'\'\n  translation: \'\'\n")
+    expect(subject.missing_translations_to_yaml).to eq("---\nnl:\n  missing_scope:\n    key_scope:\n      translation: \'\'\n      foobar: \'\'\n    foobar: \'\'\n  translation: \'\'\n")
   end
 
   it "integrates with I18n.t nicely" do


### PR DESCRIPTION
In this PR i'd like to introduce 2 changes.

## Multi locale support for store_missing_translations
The exception_handler's `store_missing_translations`, previously stored translations only in one locale. Since most systems use multiple locale files with exactly the same structure, I included `duplicate_to_locale`. Passing locales to this parameter, ensures that missing_translations for the primary locale are copied for all given locales.

  This structures the missing_translation file as follows:
  ```
  nl:
    missing_scope:
      key_scope:
        new_translation: ''
  en:
    missing_scope:
      key_scope:
        new_translation: ''
  ```
  This makes it easier to translate for multiple locales at once. You can now use:
  `I18n.exception_handler.store_missing_translations(duplicate_to_locales: I18n.available_locales)`
  To include all locales in your application.

## Multi locale support merge_missing_translation
The `merge_missing_translation` script, only supported one hardcoded locale, nl. Now it supports multiple locales, and uses every locale available in the missing_translations file.

## Specs
I've also added a spec and fixed the failing specs. The specs currently present on the main branch were failing due to two reasons.
1. Hashes are now exporting with single qoutes ' instead of double ".
2. exception_handler's missing_translations_to_yaml does not sort, but the spec assumed it would.