### PR TITLE
Fixed bug where existing translation values of secondary locale where overwritten on adding new translations.

### DIFF
--- a/lib/i18n/workflow/exception_handler.rb
+++ b/lib/i18n/workflow/exception_handler.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/hash/deep_merge'
-require 'active_support/core_ext/hash/deep_dup'
-require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/object/deep_dup'
+require 'active_support/core_ext/hash'
 require 'i18n'
 require 'yaml'
 
@@ -106,15 +105,15 @@ module I18n
         duplicate_to_locales.each do |available_locale|
           available_locale = available_locale.to_s
           source_translations = missing_translation_hash[locale.to_s].deep_dup
-          
+
           if missing_translation_hash.key?(available_locale)
             # Merge only missing keys from source locale
             source_translations.each do |key, value|
               missing_translation_hash[available_locale][key] ||= ""
             end
           else
-            # Create new locale with all translations
-            missing_translation_hash[available_locale] = source_translations.transform_values { "" }
+            # Create new locale with all translations but without original locale values
+            missing_translation_hash[available_locale] = source_translations.deep_transform_values { "" }
           end
         end
 

--- a/lib/i18n/workflow/exception_handler.rb
+++ b/lib/i18n/workflow/exception_handler.rb
@@ -88,6 +88,36 @@ module I18n
         end
         current_missing_translations = {} unless current_missing_translations.is_a?(Hash)
 
+        missing_translation_hash = missing_translations_to_hash(locale)
+                                    .deep_stringify_keys
+                                    .deep_merge(current_missing_translations)
+                                    .transform_keys(&:to_s)
+
+        duplicate_to_locales.each do |available_locale|
+          available_locale = available_locale.to_s
+          source_translations = missing_translation_hash[locale.to_s].deep_dup
+
+          if missing_translation_hash.key?(available_locale)
+            # Deep merge only missing keys from source locale
+            missing_translation_hash[available_locale].deep_merge!(source_translations) { |_, old_val, new_val|
+              old_val.is_a?(Hash) ? old_val : old_val.presence || ""
+            }
+          else
+            # Create new locale with all translations but without original locale values
+            missing_translation_hash[available_locale] = source_translations.deep_transform_values { "" }
+          end
+        end
+
+        missing_translation_hash = missing_translation_hash.transform_values(&proc)
+
+        file = File.open(missing_translations_path, "w+")
+        file.write(missing_translation_hash.deep_stringify_keys.to_yaml(line_width: -1))
+        file.close
+
+        clear_missing_translations
+      end
+
+      def proc 
         proc = Proc.new do |v|
           if v.kind_of?(Hash)
             v.transform_keys(&:to_s).sort_by {|key, _| key.to_s }.to_h.transform_values(&proc)
@@ -95,33 +125,6 @@ module I18n
             v
           end
         end
-
-        missing_translation_hash = missing_translations_to_hash(locale)
-                                    .deep_stringify_keys
-                                    .deep_merge(current_missing_translations)
-                                    .transform_keys(&:to_s)
-                                    .transform_values(&proc)
-
-        duplicate_to_locales.each do |available_locale|
-          available_locale = available_locale.to_s
-          source_translations = missing_translation_hash[locale.to_s].deep_dup
-
-          if missing_translation_hash.key?(available_locale)
-            # Merge only missing keys from source locale
-            source_translations.each do |key, value|
-              missing_translation_hash[available_locale][key] ||= ""
-            end
-          else
-            # Create new locale with all translations but without original locale values
-            missing_translation_hash[available_locale] = source_translations.deep_transform_values { "" }
-          end
-        end
-
-        file = File.open(missing_translations_path, "w+")
-        file.write(missing_translation_hash.deep_stringify_keys.to_yaml(line_width: -1))
-        file.close
-
-        clear_missing_translations
       end
     end
   end

--- a/spec/i18n/workflow/exception_handler_spec.rb
+++ b/spec/i18n/workflow/exception_handler_spec.rb
@@ -134,4 +134,40 @@ describe I18n::Workflow::ExceptionHandler do
 
     subject.store_missing_translations(duplicate_to_locales: [:en])
   end
+
+  it 'works nicely with nested existing translations in multiple locales' do 
+    allow(subject).to receive(:missing_translations?).and_return(true)
+    allow(subject).to receive(:missing_translations_to_hash).and_return(
+      { nl: { translation_scope: { translation_key_two: "" } } }
+    )
+
+    allow(File).to receive(:exist?).with("config/missing_translations.yml").and_return(true)
+    expect(YAML).to receive(:load_file).with("config/missing_translations.yml").and_return({
+      nl: { translation_key_one: "A Dutch translation" },
+      en: { translation_key_one: "An English translation" }
+    }.deep_stringify_keys)
+
+    allow(File).to receive(:open).with("config/missing_translations.yml", "w+").and_return(file)
+    expect(file).to receive(:write).with("---\nnl:\n  translation_key_one: A Dutch translation\n  translation_scope:\n    translation_key_two: \'\'\nen:\n  translation_key_one: An English translation\n  translation_scope:\n    translation_key_two: \'\'\n")
+
+    subject.store_missing_translations(duplicate_to_locales: [:en])
+  end
+
+  it 'works with deeply nested existing translations in multiple locales' do \
+    allow(subject).to receive(:missing_translations?).and_return(true)
+    allow(subject).to receive(:missing_translations_to_hash).and_return(
+      { nl: { translation_scope_two: { foo: "" , translation_scope_three: { bar: "" }} } }
+    )
+
+    allow(File).to receive(:exist?).with("config/missing_translations.yml").and_return(true)
+    expect(YAML).to receive(:load_file).with("config/missing_translations.yml").and_return({
+      nl: { translation_key_one: "A Dutch translation", translation_scope_two: { translation_key_two: "Dutch translation 2", translation_scope_three: { translation_key_three: "Dutch translation 3" } } },
+      en: { translation_key_one: "An English translation", translation_scope_two: { translation_key_two: "English translation 2", translation_scope_three: { translation_key_three: "English translation 3" } } }
+    }.deep_stringify_keys)
+
+    allow(File).to receive(:open).with("config/missing_translations.yml", "w+").and_return(file)
+    expect(file).to receive(:write).with("---\nnl:\n  translation_key_one: A Dutch translation\n  translation_scope_two:\n    foo: \'\'\n    translation_key_two: Dutch translation 2\n    translation_scope_three:\n      bar: \'\'\n      translation_key_three: Dutch translation 3\nen:\n  translation_key_one: An English translation\n  translation_scope_two:\n    foo: \'\'\n    translation_key_two: English translation 2\n    translation_scope_three:\n      bar: \'\'\n      translation_key_three: English translation 3\n")
+
+    subject.store_missing_translations(duplicate_to_locales: [:en])
+  end
 end


### PR DESCRIPTION
Er zat in bug in de missing_translations waarbij er bestaande values voor de keys van de `en` locale werden overschreven wanneer er nieuwe keys werden toegevoegd. Deze PR fixt dat en voegt een spec to voor die case. 

Korte uitleg van het probleem: 

Je `missing_translations.yml` heeft de volgende inhoud:
```
---
nl:
  test_key: Test key in Nederlands
en:
  test_key: Test key in English
```

Als je vervolgens in ergens in een template `I18n.t('test_key_two')` zet, wordt de missing_translation aangepast naar het volgende:
```
---
nl:
  test_key: Test key in Nederlands
  test_key_two: ''
en:
  test_key: Test key in Nederlands
  test_key_two: ''
```

De waarde van de `en` locale werd hierbij overschreven. 
